### PR TITLE
match original animation_speed

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -34,11 +34,11 @@ if not settings.startup["blueberry-character-visible"].value then
 	local properties = require("minimal-no-base-mod.properties")
 	for q = 1, #character.animations do
 		character.animations[q] = {
-			idle = properties.rotated_animation(),
-			idle_with_gun = properties.rotated_animation(),
-			running = properties.rotated_animation(),
-			running_with_gun = properties.rotated_sprite_custom_direction_count(18),
-			mining_with_tool = properties.rotated_animation(),
+			idle = properties.rotated_animation_custom_animation_speed(character.animations[q].idle),
+			idle_with_gun = properties.rotated_animation_custom_animation_speed(character.animations[q].idle_with_gun),
+			running = properties.rotated_animation_custom_animation_speed(character.animations[q].running),
+			running_with_gun = properties.rotated_sprite_custom_direction_count_and_animation_speed(18, character.animations[q].running_with_gun),
+			mining_with_tool = properties.rotated_animation_custom_animation_speed(character.animations[q].mining_with_tool),
 		}
 	end
 end

--- a/minimal-no-base-mod/properties.lua
+++ b/minimal-no-base-mod/properties.lua
@@ -75,4 +75,23 @@ properties.rotated_animation = function()
   animation.direction_count = 1
   return animation
 end
+properties.rotated_animation_custom_animation_speed = function(rotated_animation)
+  local animation = properties.animation()
+  animation.direction_count = 1
+  animation.animation_speed = properties.get_animation_speed(rotated_animation)
+  return animation
+end
+properties.rotated_sprite_custom_direction_count_and_animation_speed = function(direction_count, rotated_animation)
+  local sprite = properties.sprite()
+  sprite.filename = properties.sprite_filename_32px
+  sprite.direction_count = direction_count
+  sprite.animation_speed = properties.get_animation_speed(rotated_animation)
+  return sprite
+end
+properties.get_animation_speed = function(rotated_animation)
+  if (rotated_animation['layers'] ~= nil) then
+    rotated_animation = rotated_animation.layers[1]
+  end
+  return rotated_animation.animation_speed / rotated_animation.frame_count
+end
 return properties


### PR DESCRIPTION
To fix weird mining and running animations.
Since currently it uses only one animation frame - animations like "hit_rock" or "steps_on_ground" are drawing ~60 times per second. With current changes all animation_speed will be set to value in between ~0.027...0.034 to sync with the original animations.